### PR TITLE
WebSocket Reverse Proxy Implementation for VMWare 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change log
 
+## Version Release 1.5.2 (2021/04/05)
+
+#### Bugs Fixed
+
+* [Issue 1132](https://github.com/TooTallNate/Java-WebSocket/issues/1132) - Draft_6455 flagged by Veracode CWE-331 replace Random with SecureRandom ([PR 1133 ](https://github.com/TooTallNate/Java-WebSocket/pull/1133) by [@marci4](https://github.com/marci4))
+* [Issue 1053](https://github.com/TooTallNate/Java-WebSocket/issues/1053) - It's an invalid check null with SEC_WEB_SOCKET_KEY . ([PR 1054 ](https://github.com/TooTallNate/Java-WebSocket/pull/1054) by [@dota17](https://github.com/dota17))
+* [Issue 1026](https://github.com/TooTallNate/Java-WebSocket/issues/1026) - Force client to use the valid schema ([PR 1025 ](https://github.com/TooTallNate/Java-WebSocket/pull/1025) by [@yindex](https://github.com/yindex))
+* [PR 1070](https://github.com/TooTallNate/Java-WebSocket/pull/1070) - Prioritise using provided socket factory when creating socket with proxy, by [@marci4](https://github.com/marci4)
+* [PR 1028](https://github.com/TooTallNate/Java-WebSocket/pull/1028) - Fixed typo in WebSocketClient.reset's error message, by [@alphaho](https://github.com/alphaho)
+* [PR 1018](https://github.com/TooTallNate/Java-WebSocket/pull/1018) - Added missing return character, by [@pawankgupta-se](https://github.com/pawankgupta-se)
+
+#### New Features
+
+* [Issue 1008](https://github.com/TooTallNate/Java-WebSocket/issues/1008) - Improve Sec-WebSocket-Protocol usability ([PR 1034 ](https://github.com/TooTallNate/Java-WebSocket/pull/1034) by [@marci4](https://github.com/marci4))
+
+#### Refactoring
+
+* [Issue 1050](https://github.com/TooTallNate/Java-WebSocket/issues/1050) - What about adding the CodeFormatterProfile.xml with the code format ? ([PR 1060 ](https://github.com/TooTallNate/Java-WebSocket/pull/1060) by [@dota17](https://github.com/dota17))
+* [PR 1072](https://github.com/TooTallNate/Java-WebSocket/pull/1072) - Improve code quality, by [@marci4](https://github.com/marci4)
+* [PR 1060](https://github.com/TooTallNate/Java-WebSocket/pull/1060) - Using Google Java Code Style To Reformat Code, by [@dota17](https://github.com/dota17)
+
+In this release 5 issues and 9 pull requests were closed.
+
+###############################################################################
+
 ## Version Release 1.5.1 (2020/05/10)
 
 #### Bugs Fixed
@@ -7,6 +32,8 @@
 * [Issue 1011](https://github.com/TooTallNate/Java-WebSocket/issues/1011) - Crash on Android due to missing method `setEndpointIdentificationAlgorithm` on 1.5.0. ([PR 1014](https://github.com/TooTallNate/Java-WebSocket/pull/1014))
 
 In this release 1 issue and 1 pull request were closed.
+
+###############################################################################
 
 ## Version Release 1.5.0 (2020/05/06)
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = 'org.java-websocket'
-version = '1.5.2-SNAPSHOT'
+version = '1.5.3-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
-apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'maven'
-
+plugins {
+    id 'java'
+    id 'idea'
+    id 'maven-publish'
+}
 
 repositories {
     mavenLocal()
@@ -10,34 +11,32 @@ repositories {
 
 group = 'org.java-websocket'
 version = '1.5.2-SNAPSHOT'
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
-configurations {
-    deployerJars
+compileJava {
+    options.compilerArgs += ['-encoding', 'UTF-8']
 }
 
-configure(install.repositories.mavenInstaller) {
-    pom.version = project.version
-    pom.groupId = "org.java-websocket"
-    pom.artifactId = 'Java-WebSocket'
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = project.group
+            artifactId = 'Java-WebSocket'
+            version = project.version
+
+            from components.java
+        }
+    }
 }
 
 dependencies {
-    deployerJars "org.apache.maven.wagon:wagon-webdav:1.0-beta-2"
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.json', name: 'json', version: '20180813'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.json', name: 'json', version: '20180813'
 }
-
-
-//deploy to maven repository
-//uploadArchives {
-//    repositories.mavenDeployer {
-//        configuration = configurations.deployerJars
-//        repository(url: repositoryUrl) {
-//			authentication(userName: repositoryUsername, password: repositoryPassword)
-//		}
-//    }
-//}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.java-websocket</groupId>
     <artifactId>Java-WebSocket</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.5.3-SNAPSHOT</version>
     <name>Java-WebSocket</name>
     <description>A barebones WebSocket client and server implementation written 100% in Java</description>
     <url>https://github.com/TooTallNate/Java-WebSocket</url>
@@ -226,6 +226,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/main/java/org/java_websocket/SSLSocketChannel.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel.java
@@ -417,7 +417,7 @@ public class SSLSocketChannel implements WrappedByteChannel, ByteChannel, ISSLCh
   }
 
   /**
-   * Compares <code>sessionProposedCapacity<code> with buffer's capacity. If buffer's capacity is
+   * Compares sessionProposedCapacity with buffer's capacity. If buffer's capacity is
    * smaller, returns a buffer with the proposed capacity. If it's equal or larger, returns a buffer
    * with capacity twice the size of the initial one.
    *

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -955,12 +955,16 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
   @Override
   public boolean hasSSLSupport() {
-    return engine.hasSSLSupport();
+    return socket instanceof SSLSocket;
   }
 
   @Override
   public SSLSession getSSLSession() {
-    return engine.getSSLSession();
+    if (!hasSSLSupport()) {
+      throw new IllegalArgumentException(
+          "This websocket uses ws instead of wss. No SSLSession available.");
+    }
+    return ((SSLSocket)socket).getSession();
   }
 
   @Override

--- a/src/main/java/org/java_websocket/drafts/Draft_6455.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_6455.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -36,7 +37,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
 import java.util.TimeZone;
 import org.java_websocket.WebSocketImpl;
 import org.java_websocket.enums.CloseHandshakeType;
@@ -150,7 +150,7 @@ public class Draft_6455 extends Draft {
   /**
    * Attribute for the reusable random instance
    */
-  private final Random reuseableRandom = new Random();
+  private final SecureRandom reuseableRandom = new SecureRandom();
 
   /**
    * Attribute for the maximum allowed size of a frame

--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxy.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxy.java
@@ -1,0 +1,90 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.extensions.DefaultExtension;
+import org.java_websocket.extensions.IExtension;
+import org.java_websocket.protocols.IProtocol;
+import org.java_websocket.protocols.Protocol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+/**
+ *                       -----------------------------
+ *     WS CLIENT <---->  || serverSide - clientSide || <----> WS SERVER
+ *                       -----------------------------
+ */
+public class WebSocketReverseProxy implements Runnable {
+
+    private static WebSocketReverseProxyClientSide clientSide;
+    private static WebSocketReverseProxyServerSide serverSide;
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxy.class.getName());
+
+    private String wsUrl;
+
+    private static final int SERVER_SIDE_PORT = 1234;
+    private Draft_6455 draft;
+
+    private Thread selectorThread;
+
+    public void start() {
+        if (selectorThread != null) {
+            throw new IllegalStateException(getClass().getName() + " can only be started once.");
+        }
+        new Thread(this).start();
+        selectorThread = Thread.currentThread();
+    }
+
+    public WebSocketReverseProxy(String wsUrl) {
+        this.wsUrl = wsUrl;
+    }
+
+    private void initServerSide() {
+        Protocol protocol = new Protocol("binary");
+        DefaultExtension defaultExtension = new DefaultExtension();
+        draft = new Draft_6455(Collections.<IExtension>singletonList(defaultExtension), Collections.<IProtocol>singletonList(protocol));
+        serverSide = new WebSocketReverseProxyServerSide(SERVER_SIDE_PORT, this, Collections.<Draft>singletonList(draft));
+        serverSide.start();
+        logger.info("[REVERSE-PROXY] Server side started on port " + SERVER_SIDE_PORT);
+    }
+
+    @Override
+    public void run() {
+        initServerSide();
+        boolean interrupted = false;
+        while (!interrupted) {
+            interrupted = selectorThread.isInterrupted();
+        }
+    }
+
+    public void initClientSide() throws URISyntaxException {
+        URI uri = new URI(wsUrl);
+        clientSide = new WebSocketReverseProxyClientSide(uri, this, draft);
+        clientSide.connect();
+        logger.info("[REVERSE-PROXY] Client side connected to " + wsUrl);
+    }
+
+    public void proxyMsgServerToClientSide(ByteBuffer msg) {
+        try {
+            if (clientSide == null) {
+                initClientSide();
+            }
+            clientSide.receiveProxiedMsg(msg);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void proxyMsgClientToServerSide(ByteBuffer msg) {
+        try {
+            serverSide.receiveProxiedMessage(msg);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyClientSide.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyClientSide.java
@@ -1,0 +1,82 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.handshake.ServerHandshake;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.logging.Logger;
+
+public class WebSocketReverseProxyClientSide extends WebSocketClient {
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxyClientSide.class.getName());
+    private WebSocketReverseProxy reverseProxy;
+
+    private void acceptAllCerts() {
+        TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return new java.security.cert.X509Certificate[]{};
+            }
+            public void checkClientTrusted(X509Certificate[] chain,
+                                           String authType) throws CertificateException {
+            }
+            public void checkServerTrusted(X509Certificate[] chain,
+                                           String authType) throws CertificateException {
+            }
+        }};
+        SSLContext sc;
+        try {
+            sc = SSLContext.getInstance("TLS");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            SSLSocketFactory factory = sc.getSocketFactory();
+            this.setSocketFactory(factory);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public WebSocketReverseProxyClientSide(URI wsEsxiUri, WebSocketReverseProxy reverseProxy, Draft_6455 draft) {
+        super(wsEsxiUri, draft);
+        this.reverseProxy = reverseProxy;
+        acceptAllCerts();
+    }
+
+    @Override
+    public void onOpen(ServerHandshake serverHandshake) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Open connection");
+    }
+
+    @Override
+    public void onMessage(String message) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Message: " + message);
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Close connection: " + reason + " " + code + " " + remote);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        logger.info("[REVERSE-PROXY] [CLIENT SIDE] Error: " + ex.getLocalizedMessage());
+        ex.printStackTrace();
+    }
+
+    @Override
+    public void onMessage(ByteBuffer bytes) {
+        logger.finer("[REVERSE-PROXY] [CLIENT SIDE] Received frame, proxying to server");
+        this.reverseProxy.proxyMsgClientToServerSide(bytes);
+    }
+
+    public void receiveProxiedMsg(ByteBuffer msg) {
+        logger.finer("[REVERSE-PROXY] [CLIENT SIDE] Received proxied msg, sending to ESX host");
+        this.getConnection().send(msg);
+    }
+}

--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyServerSide.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyServerSide.java
@@ -1,0 +1,67 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class WebSocketReverseProxyServerSide extends WebSocketServer {
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxyServerSide.class.getName());
+    private WebSocketReverseProxy reverseProxy;
+    private WebSocket conn;
+
+    public WebSocketReverseProxyServerSide(int port, WebSocketReverseProxy reverseProxy, List<Draft> draftList) {
+        super(new InetSocketAddress(port), draftList);
+        this.reverseProxy = reverseProxy;
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Open connection - client connected successfully. Starting client connection");
+        this.conn = conn;
+        try {
+            this.reverseProxy.initClientSide();
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Close connection: " + reason + " " + code + " " + remote);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Message received: " + message);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, ByteBuffer message) {
+        logger.finer("[REVERSE-PROXY] [SERVER SIDE] Proxing message to client");
+        this.reverseProxy.proxyMsgServerToClientSide(message);
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Error " + ex.getLocalizedMessage());
+        ex.printStackTrace();
+    }
+
+    @Override
+    public void onStart() {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Started");
+    }
+
+    public void receiveProxiedMessage(ByteBuffer msg) {
+        logger.finer("[REVERSE-PROXY] [SERVER SIDE] Sending msg to client (noVNC)");
+        conn.send(msg);
+    }
+}

--- a/src/test/java/org/java_websocket/issues/Issue1142Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue1142Test.java
@@ -1,0 +1,138 @@
+package org.java_websocket.issues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.CountDownLatch;
+import javax.net.ssl.SSLContext;
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SSLContextUtil;
+import org.java_websocket.util.SocketUtil;
+import org.junit.Test;
+
+public class Issue1142Test {
+
+
+
+  @Test(timeout = 4000)
+  public void testWithoutSSLSession()
+      throws IOException, URISyntaxException, InterruptedException {
+    int port = SocketUtil.getAvailablePort();
+    final CountDownLatch countServerDownLatch = new CountDownLatch(1);
+    final WebSocketClient webSocket = new WebSocketClient(new URI("ws://localhost:" + port)) {
+      @Override
+      public void onOpen(ServerHandshake handshakedata) {
+        countServerDownLatch.countDown();
+      }
+
+      @Override
+      public void onMessage(String message) {
+      }
+
+      @Override
+      public void onClose(int code, String reason, boolean remote) {
+      }
+
+      @Override
+      public void onError(Exception ex) {
+      }
+    };
+    WebSocketServer server = new MyWebSocketServer(port, countServerDownLatch);
+    server.start();
+    countServerDownLatch.await();
+    webSocket.connectBlocking();
+    assertFalse(webSocket.hasSSLSupport());
+    try {
+      webSocket.getSSLSession();
+      assertFalse(false);
+    } catch (IllegalArgumentException e) {
+      // Fine
+    }
+    server.stop();
+  }
+
+  @Test(timeout = 4000)
+  public void testWithSSLSession()
+      throws IOException, URISyntaxException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, UnrecoverableKeyException, CertificateException, InterruptedException {
+    int port = SocketUtil.getAvailablePort();
+    final CountDownLatch countServerDownLatch = new CountDownLatch(1);
+    final WebSocketClient webSocket = new WebSocketClient(new URI("wss://localhost:" + port)) {
+      @Override
+      public void onOpen(ServerHandshake handshakedata) {
+        countServerDownLatch.countDown();
+      }
+
+      @Override
+      public void onMessage(String message) {
+      }
+
+      @Override
+      public void onClose(int code, String reason, boolean remote) {
+      }
+
+      @Override
+      public void onError(Exception ex) {
+      }
+    };
+    WebSocketServer server = new MyWebSocketServer(port, countServerDownLatch);
+    SSLContext sslContext = SSLContextUtil.getContext();
+
+    server.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(sslContext));
+    webSocket.setSocketFactory(sslContext.getSocketFactory());
+    server.start();
+    countServerDownLatch.await();
+    webSocket.connectBlocking();
+    assertTrue(webSocket.hasSSLSupport());
+    assertNotNull(webSocket.getSSLSession());
+    server.stop();
+  }
+
+  private static class MyWebSocketServer extends WebSocketServer {
+
+    private final CountDownLatch countServerLatch;
+
+
+    public MyWebSocketServer(int port, CountDownLatch serverDownLatch) {
+      super(new InetSocketAddress(port));
+      this.countServerLatch = serverDownLatch;
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+      ex.printStackTrace();
+    }
+
+    @Override
+    public void onStart() {
+      countServerLatch.countDown();
+    }
+  }
+}


### PR DESCRIPTION
WebSocket Reverse Proxy Implementation for VMWare 7

````
                       -----------------------------
    WS CLIENT <---->  || serverSide - clientSide || <----> WS SERVER
                       -----------------------------
 ````

- Get a ticket from: https://10.10.4.165/mob/?moid=vm-6803&method=acquireTicket sending "webmks" param
- Replace the ticket variable on `TestWSReverseProxy` and start the main method
- Start noVNC and point it to: 'ws://localhost:1234'